### PR TITLE
Add an option to allow or disallow TailorX to set a primary fragment`…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Bot detection is done via [device-detector-js](https://www.npmjs.com/package/dev
     * `insertStart(stream, attributes, headers, index)`
     * `insertEnd(stream, attributes, headers, index)`
 * `getAssetsToPreload()` - If specified, should return array of assets that should be added to the response `Link` header for preload.
-Return value format: `{styleRefs: ['https://ex.com/style.css'], scriptRefs: ['https://ex.com/script.css']}`
+Return value format: `{styleRefs: ['https://ex.com/style.css'], scriptRefs: ['https://ex.com/script.js']}`
+* `shouldSetPrimaryFragmentAssetsToPreload` - `true` by default. This option allows or disallows TailorX to set a primary fragment's assets to the response `Link` header for preload.
 
 ## Template
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ module.exports = class Tailor extends EventEmitter {
                 getAssetsToPreload: async () => ({
                     styleRefs: [],
                     scriptRefs: []
-                })
+                }),
+                shouldSetPrimaryFragmentAssetsToPreload: true
             },
             options
         );

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -56,7 +56,8 @@ module.exports = function processRequest(options, request, response) {
         filterResponseHeaders,
         maxAssetLinks,
         getAssetsToPreload,
-        botsGuardEnabled
+        botsGuardEnabled,
+        shouldSetPrimaryFragmentAssetsToPreload
     } = options;
 
     const waitFragmentsRes = new WaitForFragmentResponses();
@@ -150,18 +151,22 @@ module.exports = function processRequest(options, request, response) {
             }
 
             // Make resources early discoverable while processing HTML
-            let assetsToPreload = getFragmentAssetsToPreload(
-                fragment.styleRefs,
-                fragment.scriptRefs,
-                request.headers
-            );
-
             const configAssets = await getAssetsToPreload(request);
-            assetsToPreload = getFragmentAssetsToPreload(
+            let assetsToPreload = getFragmentAssetsToPreload(
                 configAssets.styleRefs || [],
                 configAssets.scriptRefs || [],
                 request.headers
-            ).concat(assetsToPreload);
+            );
+
+            if (shouldSetPrimaryFragmentAssetsToPreload) {
+                assetsToPreload = assetsToPreload.concat(
+                    getFragmentAssetsToPreload(
+                        fragment.styleRefs,
+                        fragment.scriptRefs,
+                        request.headers
+                    )
+                );
+            }
 
             responseHeaders.link = assetsToPreload.join(',');
             this.emit('response', request, statusCode, responseHeaders);


### PR DESCRIPTION
…s assets to the response `Link` header for preload