### PR TITLE
feat!: simplified error handling of `fetchContext(request)` function

### DIFF
--- a/docs/Events.md
+++ b/docs/Events.md
@@ -12,8 +12,7 @@ Events may be used for logging and monitoring. Check [perf/benchmark.js](https:/
 * Error: `error(request, error)` in case an error from template (parsing,fetching) and primary error(socket/timeout/50x)
 May be invoked with 2 signatures:
     * `error(request, error)`
-    * `error(request, error, response)` - if you received event with this signature you must write response, TailorX will do nothing on it's side 
-* Context Error: `context:error(request, error)` in case of an error fetching the context
+    * `error(request, error, response)` - if you received event with this signature you must write response, TailorX will do nothing on it's side
 
 ## Fragment events
 

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -67,10 +67,7 @@ module.exports = function processRequest(options, request, response) {
         asyncStream.end();
     });
 
-    const contextPromise = fetchContext(request).catch(err => {
-        this.emit('context:error', request, err);
-        return {};
-    });
+    const contextPromise = fetchContext(request);
     const templatePromise = fetchTemplate(request, parseTemplate);
     const responseHeaders = {
         // Disable cache in browsers and proxies


### PR DESCRIPTION
This ensures that it's impossible to silently render page with incorrect context